### PR TITLE
Added specific node version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "start": "next start",
     "lint": "next lint"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "@flags-sdk/statsig": "^0.2.1",
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
Vercel was having issues with some node packages so I only had to specify the version of NodeJS we want to use in the packages.json. Deployment worked in master branch.